### PR TITLE
fix firebreak outputs -1 on grids

### DIFF
--- a/src/fire2a/cell2fire.py
+++ b/src/fire2a/cell2fire.py
@@ -364,7 +364,11 @@ def build_scars(
             if i % 100 == 0:
                 scar_raster_ds.FlushCache()
         if burn_prob:
-            burn_prob_arr += data
+            if np.any(data == -1):
+                mask = data != -1
+                burn_prob_arr[ mask ] += data[ mask ]
+            else:
+                burn_prob_arr += data
 
     if scar_poly:
         # raster for each grid


### PR DESCRIPTION
Matias realized that some "-1" where wrongly included in the burn probability calculation, when using the --firebreaks option in Cell2FireW