### PR TITLE
Logger dont repeat handlers on recall

### DIFF
--- a/src/fire2a/agglomerative_clustering.py
+++ b/src/fire2a/agglomerative_clustering.py
@@ -709,7 +709,7 @@ def main(argv=None):
         global logger
         from fire2a import setup_logger
 
-        logger = setup_logger(verbosity=args.verbose)
+        logger = setup_logger(name=__name__, verbosity=args.verbose)
 
     logger.info("args %s", args)
 

--- a/src/fire2a/agglomerative_clustering.py
+++ b/src/fire2a/agglomerative_clustering.py
@@ -709,7 +709,8 @@ def main(argv=None):
         global logger
         from fire2a import setup_logger
 
-        logger = setup_logger(name=__name__, verbosity=args.verbose)
+        name = __name__ if __name__ != "__main__" else "fire2a.agglomerative_clustering"
+        logger = setup_logger(name, verbosity=args.verbose)
 
     logger.info("args %s", args)
 

--- a/src/fire2a/cell2fire.py
+++ b/src/fire2a/cell2fire.py
@@ -366,7 +366,7 @@ def build_scars(
         if burn_prob:
             if np_any(data == -1):
                 mask = data != -1
-                burn_prob_arr[ mask ] += data[ mask ]
+                burn_prob_arr[mask] += data[mask]
             else:
                 burn_prob_arr += data
 
@@ -566,8 +566,7 @@ def build_stats(
     callback=None,
     feedback=None,
 ):
-    """Builds final statistics raster (1 band per-simulation) and summary raster (2 bands: mean against pixel burn count and stdev against total number of simulations) files
-    """
+    """Builds final statistics raster (1 band per-simulation) and summary raster (2 bands: mean against pixel burn count and stdev against total number of simulations) files"""
     from numpy import float32 as np_float32
     from numpy import loadtxt as np_loadtxt
     from numpy import sqrt as np_sqrt
@@ -635,7 +634,7 @@ def build_stats(
             mask = data != -9999
             tmp = data[mask]
             summed[mask] += tmp
-            sumsquared[mask] += tmp ** 2
+            sumsquared[mask] += tmp**2
             burncount[mask & (data != 0)] += 1
 
         if callback:
@@ -668,7 +667,7 @@ def build_stats(
         # std
         # from all simulations
         N = len(files)
-        stddev = np_sqrt(sumsquared / N - (summed/N)**2)
+        stddev = np_sqrt(sumsquared / N - (summed / N) ** 2)
         # beacause this is always zero:
         # stddev = np_zeros((H, W), dtype=np_float32) - 9999
         # zero_mask = burncount == 0

--- a/src/fire2a/cell2fire.py
+++ b/src/fire2a/cell2fire.py
@@ -772,7 +772,8 @@ def main(argv=None):
         global logger
         from fire2a import setup_logger
 
-        logger = setup_logger(name=__name__, verbosity=args.verbose, logfile=args.logfile)
+        name = __name__ if __name__ != "__main__" else "fire2a.cell2fire"
+        logger = setup_logger(name, verbosity=args.verbose, logfile=args.logfile)
         # set other modules logging level
         logging.getLogger("asyncio").setLevel(logging.INFO)
 

--- a/src/fire2a/cell2fire.py
+++ b/src/fire2a/cell2fire.py
@@ -773,7 +773,7 @@ def main(argv=None):
         global logger
         from fire2a import setup_logger
 
-        logger = setup_logger(verbosity=args.verbose, logfile=args.logfile)
+        logger = setup_logger(name=__name__, verbosity=args.verbose, logfile=args.logfile)
         # set other modules logging level
         logging.getLogger("asyncio").setLevel(logging.INFO)
 

--- a/src/fire2a/downstream_protection_value.py
+++ b/src/fire2a/downstream_protection_value.py
@@ -450,7 +450,8 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
     args = argument_parser(argv)
-    logger = setup_logger(name=__name__, args.verbosity, args.logfile)
+    name = __name__ if __name__ != "__main__" else "fire2a.downstream_protection_value"
+    logger = setup_logger(name, args.verbosity, args.logfile)
     logger.info(f"{args=}")
     logger.debug("debugging...")
 

--- a/src/fire2a/downstream_protection_value.py
+++ b/src/fire2a/downstream_protection_value.py
@@ -450,7 +450,7 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
     args = argument_parser(argv)
-    logger = setup_logger(__name__, args.verbosity, args.logfile)
+    logger = setup_logger(name=__name__, args.verbosity, args.logfile)
     logger.info(f"{args=}")
     logger.debug("debugging...")
 

--- a/src/fire2a/knapsack.py
+++ b/src/fire2a/knapsack.py
@@ -299,7 +299,7 @@ def pre_solve(argv):
         global logger
         from fire2a import setup_logger
 
-        logger = setup_logger(verbosity=args.verbose)
+        logger = setup_logger(name=__name__, verbosity=args.verbose)
 
     logger.info("args %s", args)
 

--- a/src/fire2template/documenting.py
+++ b/src/fire2template/documenting.py
@@ -133,7 +133,7 @@ class AClass:
 
 def main(argv):
     """This is a function docstring that describes a function"""
-    logger = setup_logger(__name__, 2, None)
+    logger = setup_logger(name=__name__, 2, None)
     logger.info("Hello world!")
     logger.info(f"argv:{argv}")
     returns = b_method((1, "a"), "b", "c", an_optional_argument=2, d="e", f="g")

--- a/src/fire2template/documenting.py
+++ b/src/fire2template/documenting.py
@@ -133,7 +133,8 @@ class AClass:
 
 def main(argv):
     """This is a function docstring that describes a function"""
-    logger = setup_logger(name=__name__, 2, None)
+    name = __name__ if __name__ != "__main__" else "fire2a.documenting"
+    logger = setup_logger(name, 2, None)
     logger.info("Hello world!")
     logger.info(f"argv:{argv}")
     returns = b_method((1, "a"), "b", "c", an_optional_argument=2, d="e", f="g")

--- a/src/fire2template/template.py
+++ b/src/fire2template/template.py
@@ -143,7 +143,7 @@ def main(argv=None):
         global logger
         from fire2template import setup_logger
 
-        logger = setup_logger(verbosity=args.verbose, logfile=args.logfile)
+        logger = setup_logger(name=__name__, verbosity=args.verbose, logfile=args.logfile)
         # set other modules logging level
         logging.getLogger("asyncio").setLevel(logging.INFO)
 

--- a/src/fire2template/template.py
+++ b/src/fire2template/template.py
@@ -143,7 +143,8 @@ def main(argv=None):
         global logger
         from fire2template import setup_logger
 
-        logger = setup_logger(name=__name__, verbosity=args.verbose, logfile=args.logfile)
+        name = __name__ if __name__ != "__main__" else "fire2a.template"
+        logger = setup_logger(name, verbosity=args.verbose, logfile=args.logfile)
         # set other modules logging level
         logging.getLogger("asyncio").setLevel(logging.INFO)
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/85ba03d1-a13d-4b3f-b2fa-a27f89916480)
On QGIS, when repeatedly calling an fire2a-lib algorithm with verbose, it sets up the logger handlers again, so all logger lines such as `2025-05-26 20:28:17 INFO fire2a.agglomerative_clustering Fin...` get's repeated once more every time the algorithm is run from QGIS.

this refactoring of setup_logger avoids this, at the cost of using __main__ as logger name when calling throught cli